### PR TITLE
Add request logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ A secure, company-branded web app that updates Excel files with fund status resu
   - Write “Pass” or “Fail” into the Excel sheet
   - Color-code the cells (green/red)
   - Skip formula cells automatically
+  - Collect feature requests via a dedicated tab (saved to `user_requests.csv`)
 
 ---
 
@@ -43,6 +44,14 @@ fund-scorecard-app/
 ├── app.py                  ← Main app script
 ├── requirements.txt        ← List of needed Python packages
 ├── README.md               ← You're reading this!
+├── pages/
+│   ├── fund_scorecard.py   ← Fund scorecard workflow
+│   └── user_requests.py    ← Request submission tab
+├── utils/
+│   ├── request_store.py    ← Save submitted requests
+│   ├── excel_utils.py      ← Excel helpers
+│   ├── logger.py           ← Audit logging
+│   └── pdf_utils.py        ← PDF helpers
 ├── .streamlit/
 │   ├── config.toml         ← Custom color theme
 │   └── secrets.toml        ← Access password

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 import streamlit as st
 from datetime import datetime
-from pages import fund_scorecard
+from pages import fund_scorecard, user_requests
 
 # ======================
 #   PAGE CONFIGURATION
@@ -56,7 +56,7 @@ st.sidebar.markdown('<div class="sidebar-section">Navigate</div>', unsafe_allow_
 
 page = st.sidebar.radio(
     "",
-    ["📖 About FidSync", "🛠 How to Use", "📝 Fund Scorecard"],
+    ["📖 About FidSync", "🛠 How to Use", "📝 Fund Scorecard", "📋 Requests"],
     label_visibility="collapsed",
 )
 
@@ -107,3 +107,6 @@ elif page == "🛠 How to Use":
 
 elif page == "📝 Fund Scorecard":
     fund_scorecard.show()
+
+elif page == "📋 Requests":
+    user_requests.show()

--- a/pages/user_requests.py
+++ b/pages/user_requests.py
@@ -1,0 +1,23 @@
+import streamlit as st
+from utils import request_store
+
+
+def show():
+    """Display the user request submission form."""
+    st.title("Submit a Request")
+    st.write(
+        "Have an idea or need a new feature? Let us know how FidSync can help you."
+    )
+
+    with st.form("request_form"):
+        request_text = st.text_area("Describe what you need the program to do", height=200)
+        contact_email = st.text_input("Your email (optional)")
+        submitted = st.form_submit_button("Send Request")
+
+    if submitted:
+        if request_text.strip():
+            request_store.save_request(request_text, contact_email)
+            st.success("Thank you for your feedback!")
+        else:
+            st.warning("Please enter a description before submitting.")
+

--- a/utils/request_store.py
+++ b/utils/request_store.py
@@ -1,0 +1,16 @@
+import csv
+import os
+from datetime import datetime
+
+REQUESTS_FILE = "user_requests.csv"
+
+def save_request(description: str, email: str = "") -> None:
+    """Append a user feature request to the CSV log."""
+    entry = [datetime.now().isoformat(), description.strip(), email.strip()]
+    file_exists = os.path.isfile(REQUESTS_FILE)
+    with open(REQUESTS_FILE, mode="a", newline="") as f:
+        writer = csv.writer(f)
+        if not file_exists:
+            writer.writerow(["Timestamp", "Description", "Email"])
+        writer.writerow(entry)
+


### PR DESCRIPTION
## Summary
- save user requests into `user_requests.csv`
- call `save_request()` from the request form page
- document request logging and new file in README

## Testing
- `python -m py_compile app.py pages/*.py utils/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68698a5089c8832b8df2d4493c89a0cb